### PR TITLE
Made line number restriction looser

### DIFF
--- a/8255/construct.py
+++ b/8255/construct.py
@@ -68,8 +68,8 @@ def construct_program(lines: list[str]) -> Program:
                     raise SyntaxError("cannot begin code block without START directive")
 
                 # Check line numbers add up
-                if int(line_number) != last_line + 10:
-                    raise SyntaxError("line numbers must be multiples of 10")
+                if int(line_number) <= last_line or int(line_number) % 10:
+                    raise SyntaxError("line numbers must be increasing in multiples of 10")
 
                 last_line = int(line_number)
 


### PR DESCRIPTION
Allows line number to skip numbers in multiple of 10s. That way you don't need to constantly change the numbers for all lines when you needed to insert additional lines in previous sections of the code.

Therefore something as follows will be legal:
```8255
PROGRAM "Age and Birth Year Calculation"
START
  010   alc &age :[3]                  // Allocate 3 bytes from the stack
  020   inp "Age: " > &age             // Grab age from user and store it
  
  100   cst &age INTEGER               // Cast "age" into an INTEGER
  110   alc &born :[4]                 // Allocate 4 bytes from the stack
  120   sub 2024 &age > &born          // Subtract age from 2024 and store it
  
  200   cst &born STRING               // Cast "born" into a STRING
  210   out "You were born in $born."  // Give the user their birth year
.
```
