### PR TITLE
Fixed cls not resetting cursor to (0, 0)

### DIFF
--- a/8255/__main__.py
+++ b/8255/__main__.py
@@ -83,7 +83,7 @@ def process_file(filepath: Path, debug: bool = False) -> None:
                     exit(process_value(code))
 
                 case ["cls"]:
-                    print("\033[2J")
+                    print("\033[2J\033[0;0H", end="")
             
                 case ["alc", variable, allocation]:
                     stack.allocate_variable(

--- a/8255/__main__.py
+++ b/8255/__main__.py
@@ -83,7 +83,7 @@ def process_file(filepath: Path, debug: bool = False) -> None:
                     exit(process_value(code))
 
                 case ["cls"]:
-                    print("\033[2J\033[0;0H", end="")
+                    print("\033[2J\033[H", end = "", flush = True)
             
                 case ["alc", variable, allocation]:
                     stack.allocate_variable(


### PR DESCRIPTION
`cls` does not behave as expected.

![image](https://github.com/user-attachments/assets/205578ab-706e-4a22-b030-6d63bfb561b4)

When attempting to call `cls`, the terminal only clears the content of the screen without moving the cursor back to the origin position.

Screenshot of fixed version:

![image](https://github.com/user-attachments/assets/07d0e11b-6ed6-4e96-bda6-e827f1fb49cc)
